### PR TITLE
Update README dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ After a song finishes playing it is removed from disk. The queue is limited to 1
 
 1. Install dependencies:
    ```bash
-   pip install nextcord yt-dlp spotdl
+   pip install nextcord yt-dlp spotdl gtts
    ```
-   The bot also requires `ffmpeg` and `espeak` installed on the system.
+   The bot also requires `ffmpeg` installed on the system.
 2. Set the `DISCORD_TOKEN` environment variable with your bot token.
 3. Ensure `ffmpeg` is installed and in your PATH.
 4. Run the bot:


### PR DESCRIPTION
## Summary
- add `gtts` to the pip install example
- remove the outdated `espeak` requirement

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686f8beb11f48331915f90e52f883f82