### PR TITLE
Fix web playback from control page

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,14 @@
 </head>
 <body>
   <header>MusicBot Control</header>
+  <div id="login" style="position:fixed;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:#111;z-index:10;">
+    <div style="background:#222;padding:2em;border-radius:8px;text-align:center;">
+      <h2>Login</h2>
+      <input id="user" placeholder="Username" style="width:100%;margin-bottom:0.5em;"><br>
+      <input id="pass" placeholder="Password" type="password" style="width:100%;margin-bottom:0.5em;"><br>
+      <button onclick="doLogin()">Login</button>
+    </div>
+  </div>
   <main>
     <div>
       <button onclick="api('skip')">Skip</button>
@@ -37,10 +45,23 @@
     <ul id="queue"></ul>
   </main>
   <script>
-    const auth = 'Basic ' + btoa(prompt('Username') + ':' + prompt('Password'));
-    async function api(cmd, params='') {
-      await fetch(`/api/${cmd}${params}`, { headers:{ 'Authorization': auth } });
+    let auth = localStorage.getItem('auth') || '';
+    function showLogin(show=true) {
+      document.getElementById('login').style.display = show ? 'flex' : 'none';
+    }
+    function doLogin() {
+      const u = document.getElementById('user').value;
+      const p = document.getElementById('pass').value;
+      auth = 'Basic ' + btoa(`${u}:${p}`);
+      localStorage.setItem('auth', auth);
+      showLogin(false);
       loadQueue();
+    }
+    if (!auth) showLogin(true);
+    async function api(cmd, params='') {
+      let res = await fetch(`/api/${cmd}${params}`, { headers:{ 'Authorization': auth } });
+      if (res.status === 401) { showLogin(true); return; }
+      await loadQueue();
     }
     async function addSong() {
       let q = document.getElementById('query').value.trim();
@@ -53,6 +74,7 @@
     }
     async function loadQueue() {
       let res = await fetch('/api/queue', { headers:{ 'Authorization': auth } });
+      if (res.status === 401) { showLogin(true); return; }
       let data = await res.json();
       let ul = document.getElementById('queue');
       ul.innerHTML = '';


### PR DESCRIPTION
## Summary
- start playback when adding songs via the web API
- allow playback loop to run without a Discord interaction
- implement a simple login form instead of JS prompts

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686f8b7c02448331804d38bca75ddcf2