### PR TITLE
Enhance web UI playback controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
       <button onclick="api('pause')">Pause</button>
       <button onclick="api('resume')">Resume</button>
       <button onclick="api('clear')">Clear Queue</button>
+      <button onclick="api('loop')">Loop Song</button>
+      <button onclick="api('loopqueue')">Loop Queue</button>
     </div>
     <div style="margin-top:1em;">
       <input id="query" placeholder="Song URL or search term">
@@ -41,6 +43,10 @@
       <button onclick="joinChannel()">Join</button>
     </div>
     <div id="status" style="margin-top:1em;"></div>
+    <div style="margin-top:0.5em;">
+      <input type="range" id="progress" value="0" min="0" max="0" step="1" style="width:80%;">
+      <span id="time">0:00 / 0:00</span>
+    </div>
     <h3>Queue</h3>
     <ul id="queue"></ul>
   </main>
@@ -99,11 +105,20 @@
       let status = document.getElementById('status');
       let dls = Object.entries(data.downloads).map(([q,s]) => `${q} (${s}s)`).join('<br>');
       status.innerHTML = `Playing: ${data.current || 'none'}<br>Voice: ${data.connected || 'none'}<br>Downloading:<br>${dls || 'none'}`;
+      let prog = document.getElementById('progress');
+      let time = document.getElementById('time');
+      prog.max = Math.floor(data.duration || 0);
+      prog.value = Math.floor(data.position || 0);
+      function fmt(t){let m=Math.floor(t/60);let s=Math.floor(t%60);return `${m}:${s.toString().padStart(2,'0')}`;}
+      time.textContent = `${fmt(data.position)} / ${fmt(data.duration)}`;
     }
     async function joinChannel() {
       let id = document.getElementById('channels').value;
       if (id) await api('join', '?channel=' + id);
     }
+    document.getElementById('progress').addEventListener('change', e => {
+      api('seek', '?pos=' + e.target.value);
+    });
     loadQueue();
     setInterval(loadQueue, 5000);
   </script>


### PR DESCRIPTION
## Summary
- improve Song class and MusicPlayer to track duration and playback position
- implement seek and loop queue support
- stop browser basic auth pop‑ups by returning JSON for auth failures
- expose progress, loop flags and seek endpoint in HTTP API
- update control page with loop buttons and draggable progress bar

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686fcd8b09dc833191582dc994e52621