### PR TITLE
Fix seek progress desync

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -430,6 +430,9 @@ async def playback_loop(interaction: nextcord.Interaction | None = None):
                 break
             player.play_next.clear()
             if not player.queue:
+                if player.current and not vc.is_playing():
+                    player.current = None
+                    player.start_time = 0.0
                 await asyncio.sleep(1)
                 continue
             song = player.queue.pop(0)
@@ -540,7 +543,9 @@ def start_http_server():
                     pass
             elif cmd == 'seek' and 'pos' in params:
                 try:
-                    player.seek_pos = float(params['pos'][0])
+                    pos = float(params['pos'][0])
+                    player.seek_pos = pos
+                    player.start_time = time.time() - pos
                     if player.voice_client:
                         player.voice_client.stop()
                 except Exception:


### PR DESCRIPTION
## Summary
- update `start_time` when seeking so the web UI displays the right position immediately
- clear `player.current` once playback stops to keep status accurate

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686fdd0d3af08331a5761a2068326066