### PR TITLE
Improve Opus bitrate selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This bot uses Nextcord application commands to play music from YouTube, YouTube 
 - The bot speaks events like downloads and currently playing tracks using TTS
 - **Show Queue** context command via the Apps menu when right clicking the bot
 
+Audio is streamed at the connected channel's bitrate (clamped to 384 kb/s) or
+a default of 128 kb/s for higher quality.
+
 After a song finishes playing it is removed from disk. The queue is limited to 10 entries.
 
 ## Running

--- a/bot.py
+++ b/bot.py
@@ -108,11 +108,13 @@ def channel_bitrate() -> int:
     vc = player.voice_client
     if vc and vc.channel and getattr(vc.channel, 'bitrate', None):
         try:
-            # Clamp to Discord's supported range and convert to kbps
-            return max(32, min(vc.channel.bitrate // 1000, 128))
+            # Discord allows up to 384 kb/s for boosted servers.
+            # Convert the channel bitrate from bps to kbps and clamp it.
+            return max(32, min(vc.channel.bitrate // 1000, 384))
         except Exception:
             pass
-    return 64
+    # Default to a higher quality bitrate when the channel doesn't report one
+    return 128
 
 # ---- Voice channel helpers ----
 def list_voice_channels() -> dict[int, str]:


### PR DESCRIPTION
## Summary
- raise the Opus bitrate ceiling to 384 kb/s
- default to 128 kb/s when the channel doesn't report a bitrate
- document improved bitrate handling

## Testing
- `python3 -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686fdede97a083318e1d8a1052507fbf