### PR TITLE
Improve control panel responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This bot uses Nextcord application commands to play music from YouTube, YouTube 
 - `/play <query or url>` – download a track (YouTube or Spotify) and queue it
 - `/playlist <url>` – download a playlist and add tracks to the queue (queue size up to 10)
 - `/remove_playlist` – remove songs added by the last playlist command
+- `/clear` – clear the queue
 - `/skip` – skip the current song
 - `/loop` – toggle loop mode for the current song
 - `/back` – replay the previous song
@@ -39,6 +40,7 @@ After a song finishes playing it is removed from disk. The queue is limited to 1
    A sample `discord_music_bot.service` is provided for running with `systemctl`.
 
 The bot exposes an HTTP control server on port `8080` by default. Browse to `http://localhost:8080/` for a small control page. Set `HTTP_CONTROL_PORT` to change the port.
-The page includes a progress and volume slider for seeking and adjusting playback volume.
+The page includes progress and volume sliders for seeking and adjusting playback volume. These controls now stay responsive while dragging thanks to improved client-side handling.
+The web page also offers a playlist field to enqueue an entire playlist with one click and a button to remove those playlist songs again. Loop mode and pause state are reflected so you can easily see if looping or pausing is active.
 
 Spotify downloads require a configured `spotdl` installation and may need Spotify credentials. See [spotdl documentation](https://github.com/spotDL/spotify-downloader) for setup details.

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
     }
     .yt-btn:hover{background:var(--yt-surface-hover);}
     .yt-btn:active{background:var(--yt-accent);color:#fff;}
+    .yt-btn.toggled{background:var(--yt-accent);color:#fff;}
 
     /* INPUTS */
     .yt-input{
@@ -142,18 +143,25 @@
   <main>
     <!-- TOP CONTROLS -->
     <div class="control-row">
-      <button class="yt-btn" onclick="api('skip')"><span class="material-icons-outlined">skip_next</span>Skip</button>
-      <button class="yt-btn" onclick="api('pause')"><span class="material-icons-outlined">pause</span>Pause</button>
-      <button class="yt-btn" onclick="api('resume')"><span class="material-icons-outlined">play_arrow</span>Resume</button>
+      <button class="yt-btn" id="skipBtn" onclick="api('skip')"><span class="material-icons-outlined">skip_next</span>Skip</button>
+      <button class="yt-btn" id="pauseBtn" onclick="api('pause')"><span class="material-icons-outlined">pause</span>Pause</button>
+      <button class="yt-btn" id="resumeBtn" onclick="api('resume')"><span class="material-icons-outlined">play_arrow</span>Resume</button>
       <button class="yt-btn" onclick="api('clear')">Clear Queue</button>
-      <button class="yt-btn" onclick="api('loop')">Loop Song</button>
-      <button class="yt-btn" onclick="api('loopqueue')">Loop Queue</button>
+      <button class="yt-btn" id="loopBtn" onclick="api('loop')">Loop Song</button>
+      <button class="yt-btn" id="loopQueueBtn" onclick="api('loopqueue')">Loop Queue</button>
     </div>
 
     <!-- ADD SONG -->
     <div class="control-row">
       <input id="query" class="yt-input" placeholder="YouTube link or search term">
       <button class="yt-btn" onclick="addSong()">Add</button>
+    </div>
+
+    <!-- ADD PLAYLIST -->
+    <div class="control-row">
+      <input id="plist" class="yt-input" placeholder="Playlist URL">
+      <button class="yt-btn" onclick="addPlaylist()">Add Playlist</button>
+      <button class="yt-btn" onclick="removePlaylist()">Remove Playlist Songs</button>
     </div>
 
     <!-- JOIN CHANNEL -->
@@ -180,6 +188,10 @@
     let auth = localStorage.getItem('auth') || '';
     const showLogin = (show=true)=>document.getElementById('login').style.display = show ? 'flex' : 'none';
 
+    // track slider interactions so periodic updates don't fight with the user
+    let seeking=false, pendingSeek=0;
+    let adjustingVol=false, pendingVol=100;
+
     function doLogin(){
       const u=document.getElementById('user').value;
       const p=document.getElementById('pass').value;
@@ -200,6 +212,15 @@
       if(!q)return;
       api('add','?query='+encodeURIComponent(q));
       document.getElementById('query').value='';
+    }
+    function addPlaylist(){
+      const u=document.getElementById('plist').value.trim();
+      if(!u)return;
+      api('playlist','?url='+encodeURIComponent(u));
+      document.getElementById('plist').value='';
+    }
+    function removePlaylist(){
+      api('remove_playlist');
     }
     function removeSong(i){api('remove','?pos='+i);}
 
@@ -235,31 +256,51 @@
       /* Status */
       const dls=Object.entries(data.downloads).map(([q,s])=>`${q} (${s}s)`).join('<br>');
       document.getElementById('status').innerHTML=
-        `Playing: <strong>${data.current||'none'}</strong><br>`+
+        `Playing: <strong>${data.current||'none'}</strong>${data.paused?' (Paused)':''}<br>`+
         `Voice: ${data.connected||'none'}<br>`+
         `Downloading:<br>${dls||'none'}`;
+
+      document.getElementById('loopBtn').classList.toggle('toggled',data.loop);
+      document.getElementById('loopQueueBtn').classList.toggle('toggled',data.loop_queue);
+      document.getElementById('pauseBtn').disabled=data.paused||!data.current;
+      document.getElementById('resumeBtn').disabled=!data.paused||!data.current;
 
       /* Progress */
       const prog=document.getElementById('progress');
       const vol=document.getElementById('volume');
       const time=document.getElementById('time');
       prog.max=Math.floor(data.duration||0);
-      prog.value=Math.floor(data.position||0);
-      vol.value=data.volume||100;
+      if(!seeking){
+        prog.value=Math.floor(data.position||0);
+      }
+      if(!adjustingVol){
+        vol.value=data.volume||100;
+      }
       const fmt=t=>{const m=Math.floor(t/60),s=Math.floor(t%60).toString().padStart(2,'0');return `${m}:${s}`;};
-      time.textContent=`${fmt(data.position)} / ${fmt(data.duration)}`;
+      if(!seeking){
+        time.textContent=`${fmt(data.position)} / ${fmt(data.duration)}`;
+      }
     }
 
     function joinChannel(){
       const id=document.getElementById('channels').value;
       if(id) api('join','?channel='+id);
     }
-    document.getElementById('progress').addEventListener('change',e=>{
-      api('seek','?pos='+e.target.value);
-    });
-    document.getElementById('volume').addEventListener('change',e=>{
-      api('volume','?level='+e.target.value);
-    });
+    const prog=document.getElementById('progress');
+    const vol=document.getElementById('volume');
+
+    const endSeek=()=>{if(seeking){seeking=false;api('seek','?pos='+pendingSeek);}};
+    const endVol=()=>{if(adjustingVol){adjustingVol=false;api('volume','?level='+pendingVol);}};
+
+    prog.addEventListener('input',e=>{seeking=true;pendingSeek=e.target.value;});
+    prog.addEventListener('change',endSeek);
+    prog.addEventListener('mouseup',endSeek);
+    prog.addEventListener('touchend',endSeek);
+
+    vol.addEventListener('input',e=>{adjustingVol=true;pendingVol=e.target.value;});
+    vol.addEventListener('change',endVol);
+    vol.addEventListener('mouseup',endVol);
+    vol.addEventListener('touchend',endVol);
 
     loadQueue();setInterval(loadQueue,1000);
   </script>


### PR DESCRIPTION
## Summary
- persist pause state and expose it via the API
- highlight loop buttons and disable pause/resume appropriately in the web UI
- show loop and pause status in the README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686ff83391948331acb9d86f5acd8d74